### PR TITLE
Enable code style checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ php:
 install:
   - composer install
 script:
-  - php vendor/bin/phpunit
+  - composer test

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,12 @@
     "psr-4": {"GroupLife\\Core\\":"src/"}
   },
   "scripts": {
+    "test": ["phpunit", "@composer style"],
     "style": "phpcs --standard=PSR12 src/ tests/",
     "style-fix": "phpcbf --standard=PSR12 src/ tests/"
   },
   "scripts-descriptions": {
+    "test": "Execute all tests",
     "style": "Run the code style checker",
     "style-fix": "Fix the code style"
   }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     }
   ],
   "require-dev": {
-    "phpunit/phpunit": "^9.5"
+    "phpunit/phpunit": "^9.5",
+    "squizlabs/php_codesniffer": "^3.6"
   },
   "autoload": {
     "psr-4": {"Core\\":"src/"}

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,13 @@
   },
   "autoload": {
     "psr-4": {"Core\\":"src/"}
+  },
+  "scripts": {
+    "style": "phpcs --standard=PSR12 src/ tests/",
+    "style-fix": "phpcbf --standard=PSR12 src/ tests/"
+  },
+  "scripts-descriptions": {
+    "style": "Run the code style checker",
+    "style-fix": "Fix the code style"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "style-fix": "phpcbf --standard=PSR12 src/ tests/"
   },
   "scripts-descriptions": {
-    "test": "Execute all tests",
+    "test": "Run the all tests",
     "style": "Run the code style checker",
     "style-fix": "Fix the code style"
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d094a7758f05e5583d06647a73f944e",
+    "content-hash": "5659a75462916c69341ee3aa59c623b5",
     "packages": [],
     "packages-dev": [
         {
@@ -1910,6 +1910,62 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Core;
+
 class Visitor
 {
     private $name;
@@ -11,7 +12,8 @@ class Visitor
         $this->name = $name;
         $this->surname = $surname;
     }
-    public function returnFullName ()
+
+    public function returnFullName()
     {
         return 'My name is ' . $this->name . ' ' . $this->surname;
     }

--- a/tests/VisitorTest.php
+++ b/tests/VisitorTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace GroupLife\Core\tests;
+
 use PHPUnit\Framework\TestCase;
 use Core\Visitor;
 


### PR DESCRIPTION
We need some formal rules for code style to focus on the work itself.

Here I propose to follow PSR-12 coding standard. The automatic check will be included in the tests suite, just always use `composer test` to execute our tests.