### PR TITLE
Activity data mapper

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -70,4 +70,12 @@ class Activity implements \JsonSerializable
         $data->leader = $this->leader;
         return $data;
     }
+
+    /**
+     * @param int $id
+     */
+    public function persists(int $id): void
+    {
+        $this->id = $id;
+    }
 }

--- a/src/DataMapper/ActivityMapper.php
+++ b/src/DataMapper/ActivityMapper.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GroupLife\Core\DataMapper;
+
+use GroupLife\Core\Activity;
+use GroupLife\Core\Exception\SavingToDbIsForbidden;
+
+class ActivityMapper
+{
+    private $connection;
+
+    public function __construct(\Doctrine\DBAL\Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @param Activity $activity
+     * @throws SavingToDbIsForbidden
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function insert(Activity $activity)
+    {
+        $data = getDataObject($activity);
+        if (!empty($data->id)) {
+            throw new SavingToDbIsForbidden('Object is already in the database');
+        }
+        if (empty($data->schedule->id)) {
+            throw new SavingToDbIsForbidden('Schedule Object was not saved in the database');
+        }
+        if (empty($data->leader->id)) {
+            throw new SavingToDbIsForbidden('Leader Object was not saved in the database');
+        }
+
+        $this->connection->insert(
+            'activity',
+            [
+                'name' => $data->name,
+                'schedule_id' => $data->schedule->id,
+                'leader_id' => $data->leader->id
+            ]
+        );
+        $activity->persists((int)$this->connection->lastInsertId());
+    }
+
+    /**
+     * @param int $id
+     * @param LeaderMapper $leaderMapper
+     * @param ScheduleMapper $scheduleMapper
+     * @return Activity
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function find(int $id, LeaderMapper $leaderMapper, ScheduleMapper $scheduleMapper): Activity
+    {
+        $data = $this->connection->fetchAssociative('SELECT * FROM activity WHERE id=?', [$id]);
+        $activity =  new Activity(
+            $data['name'],
+            $scheduleMapper->find((int)$data['schedule_id']),
+            $leaderMapper->find((int)$data['leader_id'])
+        );
+        $activity->persists($id);
+        return $activity;
+    }
+}

--- a/src/Exception/SavingToDbIsForbidden.php
+++ b/src/Exception/SavingToDbIsForbidden.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GroupLife\Core\Exception;
+
+class SavingToDbIsForbidden extends \Exception
+{
+
+}

--- a/tests/integration/DataMapper/ActivityMapperTest.php
+++ b/tests/integration/DataMapper/ActivityMapperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GroupLife\Core\tests\DataMapper;
+
+use GroupLife\Core\Activity;
+use GroupLife\Core\DataMapper\ActivityMapper;
+use GroupLife\Core\DataMapper\LeaderMapper;
+use GroupLife\Core\DataMapper\ScheduleMapper;
+use GroupLife\Core\Leader;
+use GroupLife\Core\Schedule;
+use GroupLife\Core\Test\TestCaseWithDb;
+
+class ActivityMapperTest extends TestCaseWithDb
+{
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \GroupLife\Core\Exception\SavingToDbIsForbidden
+     */
+    public function testInsert()
+    {
+        $leader = new Leader('Petr', 'Petrov');
+        $schedule = new Schedule([
+            new Schedule\WeekdayRule('Monday', '10:00'),
+            new Schedule\CancelDayRule('2021-01-11', '10:00'),
+            new Schedule\CancelDayRule('2021-01-25', '10:00'),
+        ]);
+        $leaderMapper = new LeaderMapper(self::$db);
+        $scheduleMapper = new ScheduleMapper(self::$db);
+        $leaderMapper->insert($leader);
+        $scheduleMapper->insert($schedule);
+        $activity = new Activity('Chess', $schedule, $leader);
+        $mapper = new ActivityMapper(self::$db);
+        $mapper->insert($activity);
+        $sqlQuery = '
+            select
+                   a.id as activity_id,
+                   a.name as activity_name,
+                   l.name as teacher_name,
+                   l.surname as teacher_surname,
+                   count(sr.type) as schedule_type,
+                   count(sr.data) as schedule_rules
+            from activity as a
+                inner join leader l
+                    on a.leader_id = l.id
+                inner join schedule s on a.schedule_id = s.id
+            inner join schedule_rule sr on s.id = sr.schedule_id
+            where activity_id = ?
+';
+        self::assertEquals(
+            [
+                'activity_id' => (string)getDataObject($activity)->id,
+                'activity_name' => 'Chess',
+                'teacher_name' => 'Petr',
+                'teacher_surname' => 'Petrov',
+                'schedule_type' => '3',
+                'schedule_rules' => '3'
+            ],
+            self::$db->fetchAssociative($sqlQuery, [getDataObject($activity)->id])
+        );
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function testFind()
+    {
+        $mapper = new ActivityMapper(self::$db);
+        $id = 1;
+        $newActivity = $mapper->find($id, new LeaderMapper(self::$db), new ScheduleMapper(self::$db));
+        self::assertInstanceOf(Activity::class, $newActivity);
+        self::assertEquals($id, getDataObject($newActivity)->id);
+    }
+}

--- a/tests/lib/Migrations/Version20210923165030.php
+++ b/tests/lib/Migrations/Version20210923165030.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GroupLife\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210923165030 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create activity table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            create table activity
+            (
+                id integer not null
+                    constraint activity_pk
+                        primary key autoincrement,
+                name text not null,
+                schedule_id int
+                    constraint activity_schedule_id_fk
+                        references schedule (id),
+                leader_id int
+                    constraint activity_leader_id_fk
+                        references leader (id)
+            );
+        ');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('drop table activity');
+    }
+}

--- a/tests/unit/ActivityTest.php
+++ b/tests/unit/ActivityTest.php
@@ -49,7 +49,7 @@ class ActivityTest extends TestCase
 
     public function testJsonSerialize()
     {
-        self::assertEquals(
+        self::assertJsonStringEqualsJsonString(
             <<<'JSON'
 {
     "id": null,

--- a/tests/unit/LeaderTest.php
+++ b/tests/unit/LeaderTest.php
@@ -26,6 +26,6 @@ class LeaderTest extends TestCase
 
     private static function leaderIvan(): Leader
     {
-        return $leader = new Leader('Ivan', 'Ivanov');
+        return new Leader('Ivan', 'Ivanov');
     }
 }

--- a/tests/unit/LeaderTest.php
+++ b/tests/unit/LeaderTest.php
@@ -17,11 +17,11 @@ class LeaderTest extends TestCase
 
     public function testJsonSerialize()
     {
-        $object = new \stdClass();
-        $object->id = null;
-        $object->name = 'Ivan';
-        $object->surname = 'Ivanov';
-        self::assertEquals($object, getDataObject(self::leaderIvan()));
+        self::assertJsonStringEqualsJsonString('{
+                "id": null,
+                "name": "Ivan",
+                "surname": "Ivanov"
+            }', json_encode(self::leaderIvan(), JSON_PRETTY_PRINT));
     }
 
     private static function leaderIvan(): Leader

--- a/tests/unit/ScheduleTest.php
+++ b/tests/unit/ScheduleTest.php
@@ -69,27 +69,27 @@ class ScheduleTest extends TestCase
             new Schedule\CancelDayRule('2021-01-11', '10:00'),
             new Schedule\CancelDayRule('2021-01-25', '10:00'),
         ]);
-        $object = new \stdClass();
-        $object->id = null;
-        $object->rules = [];
-
-        $rule1 = new \stdClass();
-        $rule1->type = 'GroupLife\Core\Schedule\WeekdayRule';
-        $rule1->data = '{"weekday":"Monday","startTime":"10:00"}';
-
-        $rule2 = new \stdClass();
-        $rule2->type = 'GroupLife\Core\Schedule\CancelDayRule';
-        $rule2->data = '{"day":"2021-01-11","time":"10:00"}';
-
-        $rule3 = new \stdClass();
-        $rule3->type = 'GroupLife\Core\Schedule\CancelDayRule';
-        $rule3->data = '{"day":"2021-01-25","time":"10:00"}';
-
-        $object->rules = [
-            $rule1,
-            $rule2,
-            $rule3
-        ];
-        $this->assertEquals($object, getDataObject($schedule));
+        self::assertJsonStringEqualsJsonString(
+            <<<'JSON'
+    {
+        "id": null,
+        "rules": [
+            {
+                "type": "GroupLife\\Core\\Schedule\\WeekdayRule",
+                "data": "{\"weekday\":\"Monday\",\"startTime\":\"10:00\"}"
+            },
+            {
+                "type": "GroupLife\\Core\\Schedule\\CancelDayRule",
+                "data": "{\"day\":\"2021-01-11\",\"time\":\"10:00\"}"
+            },
+            {
+                "type": "GroupLife\\Core\\Schedule\\CancelDayRule",
+                "data": "{\"day\":\"2021-01-25\",\"time\":\"10:00\"}"
+            }
+        ]
+    }
+    JSON,
+            json_encode($schedule, JSON_PRETTY_PRINT)
+        );
     }
 }

--- a/tests/unit/VisitorTest.php
+++ b/tests/unit/VisitorTest.php
@@ -15,11 +15,11 @@ class VisitorTest extends TestCase
     }
     public function testJsonSerialize()
     {
-        $object = new \stdClass();
-        $object->id = null;
-        $object->name = 'Vasya';
-        $object->surname = 'Pupkin';
-        self::assertEquals($object, getDataObject(self::visitorVasya()));
+        self::assertJsonStringEqualsJsonString('{
+            "id": null,
+            "name": "Vasya",
+            "surname": "Pupkin"
+        }', json_encode(self::visitorVasya(), JSON_PRETTY_PRINT));
     }
 
     private static function visitorVasya(): Visitor


### PR DESCRIPTION
Rewrote the JSON serialization tests with the assertJsonStringEqualsJsonString method because it is not strict about EOL characters on different OSes.
Appended new exception for DB